### PR TITLE
Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [1.8.2](https://github.com/PeculiarVentures/fortify/releases/tag/1.8.2) (05.07.2021)
+
+### Bug Fixes
+
+- Fix error on `ossl` property reading of null object.
+- Change driver for the `3BDF18008131FE7D006B020C0182011101434E53103180FC` token ([#423](https://github.com/PeculiarVentures/fortify/issues/423)).
+- Fix error on key generation ([#422](https://github.com/PeculiarVentures/fortify/issues/422)).
+- Fix error on IDPrime card removing ([#421](https://github.com/PeculiarVentures/fortify/issues/421)).
+
 ## [1.8.1](https://github.com/PeculiarVentures/fortify/releases/tag/1.8.1) (01.06.2021)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fortify",
   "productName": "Fortify",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Fortify enables web applications to use smart cards, local certificate stores and do certificate enrollment",
   "main": "out/main.js",
   "scripts": {
@@ -16,7 +16,8 @@
     "clear": "rimraf out build",
     "rebuild": "yarn clear && yarn build",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx ./",
-    "test": "mocha"
+    "test": "mocha",
+    "upgrade": "yarn upgrade-interactive"
   },
   "keywords": [],
   "author": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -378,9 +378,9 @@
   integrity sha512-ZvO2tAcjmMi8V/5Z3JsyofMe3hasRcaw88cto5etSVMwVQfeivGAlEYmaQgceUSVYFofVjT+ioHsATjdWcFt1w==
 
 "@types/node@*", "@types/node@>=13.7.0":
-  version "15.6.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.6.1.tgz#32d43390d5c62c5b6ec486a9bc9c59544de39a08"
-  integrity sha512-7EIraBEyRHEe7CH+Fm1XvgqU6uwZN8Q7jppJGcqjROMT29qhAuuOxYB1uEY5UMYQKEmA5D+5tBnhdaPXSsLONA==
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.0.0.tgz#067a6c49dc7a5c2412a505628e26902ae967bf6f"
+  integrity sha512-TmCW5HoZ2o2/z2EYi109jLqIaPIi9y/lc2LmDCWzuCi35bcaQ+OtUh6nwBiFK7SOu25FAU5+YKdqFZUwtqGSdg==
 
 "@types/node@^12.0.12", "@types/node@^12.12.51":
   version "12.20.13"
@@ -659,44 +659,44 @@
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
 
-"@webcrypto-local/cards@^1.6.3":
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/@webcrypto-local/cards/-/cards-1.6.3.tgz#b591c1173a660b608800640769971edf876ac903"
-  integrity sha512-dx0TG9vmKa/JkyPkwiQZrSsKS4Yg+k+fWh3uvMCNKM3ic49fgAS2YNWBsBnyKJb05Cor8i2PrRT4xKIXk96Pgg==
+"@webcrypto-local/cards@^1.6.3", "@webcrypto-local/cards@^1.6.6":
+  version "1.6.6"
+  resolved "https://registry.yarnpkg.com/@webcrypto-local/cards/-/cards-1.6.6.tgz#abf5b5ca3efdbc5719cef5b6eafee29073dd526f"
+  integrity sha512-ow25JmAFoDEI07n90/1Qpf8YvqwDkflCchd9aFDAo8EDbz+PCjNrexy+zQBICxojxYobgGRS8cDCJOv586Eq5g==
   dependencies:
     "@peculiar/json-schema" "^1.1.12"
-    tslib "^2.2.0"
+    tslib "^2.3.0"
 
-"@webcrypto-local/core@^1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@webcrypto-local/core/-/core-1.6.1.tgz#5cd18c36772587bb9989bb568473d397833aa712"
-  integrity sha512-FjvpYokEFMSlYydsqv38SWDrfpjYiDB8CBhxFwK0jVDvTU56HRjp6qZhukJB8Pw8rNpbEBduARFWY39KEDA+pQ==
+"@webcrypto-local/core@^1.6.5":
+  version "1.6.5"
+  resolved "https://registry.yarnpkg.com/@webcrypto-local/core/-/core-1.6.5.tgz#42d05dbcdb8de8a13e15c85cdedaaa7dcbe566ea"
+  integrity sha512-mIvJ8BOhUf90eM0RgB/7gVogaacVSne4ePWb2t+M7OmCuFs2TaJTAqNR/3Wahk6XlSH3+iyrpzbowZ3bi9VR7Q==
   dependencies:
     "2key-ratchet" "^1.0.18"
     pvtsutils "^1.1.7"
-    tslib "^2.2.0"
+    tslib "^2.3.0"
 
-"@webcrypto-local/proto@^1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@webcrypto-local/proto/-/proto-1.6.1.tgz#0a74cd04215e78e76f88a7b749d29c4e2550b198"
-  integrity sha512-QzHWypZxBXIKYZomNbaG8lZpJBtZWqkXjb7mlzFBOBnFo3wN16yhXNrF83zcMweCW7a7D6V2V68aAoHxxnMNRA==
+"@webcrypto-local/proto@^1.6.5":
+  version "1.6.5"
+  resolved "https://registry.yarnpkg.com/@webcrypto-local/proto/-/proto-1.6.5.tgz#acb4cd889cc6311db5889b604cd6ee060b0a37c7"
+  integrity sha512-KBgGu9iI8IZ7zR2lpg7fH39y4euXhmTKX2xA92iTn0W7N4Mlslx8NtRy4xPaYPPfk0EvqAtIj0PYGRdRZbpeww==
   dependencies:
-    "@webcrypto-local/core" "^1.6.1"
+    "@webcrypto-local/core" "^1.6.5"
     pvtsutils "^1.1.7"
-    tslib "^2.2.0"
+    tslib "^2.3.0"
     tsprotobuf "^1.0.17"
 
 "@webcrypto-local/server@^1.6.4":
-  version "1.6.4"
-  resolved "https://registry.yarnpkg.com/@webcrypto-local/server/-/server-1.6.4.tgz#2165d117d032acb5563009d4879b558e0c55afd7"
-  integrity sha512-lqFp9XCehtgHUOMhBt1V95lsjvvn0ZaBYKLUynHiM5wsjtxA8QCD2c6+YT2owXUAXbk6Two62rHfBSO+cK8kMg==
+  version "1.6.7"
+  resolved "https://registry.yarnpkg.com/@webcrypto-local/server/-/server-1.6.7.tgz#6f0ba38e4ca7421def39b3704687750a5559cb4b"
+  integrity sha512-zf7vBUHFQYB/3cehFPSMZVoBidLDvlwIRsKarijQP4Z4doOjc2RfhudsOjlqhDCW2wOB22UtCwzoNdwSfD+jRw==
   dependencies:
     "2key-ratchet" "^1.0.18"
     "@peculiar/json-schema" "^1.1.12"
     "@types/pvutils" "^1.0.0"
-    "@webcrypto-local/cards" "^1.6.3"
-    "@webcrypto-local/core" "^1.6.1"
-    "@webcrypto-local/proto" "^1.6.1"
+    "@webcrypto-local/cards" "^1.6.6"
+    "@webcrypto-local/core" "^1.6.5"
+    "@webcrypto-local/proto" "^1.6.5"
     asn1js "^2.1.1"
     graphene-pk11 "^2.2.3"
     node-webcrypto-p11 "^2.3.6"
@@ -705,9 +705,9 @@
     pvtsutils "^1.1.7"
     pvutils "^1.0.17"
     request "^2.88.0"
-    tslib "^2.2.0"
+    tslib "^2.3.0"
     webcrypto-core "^1.1.8"
-    ws "^7.4.5"
+    ws "^7.5.1"
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -3193,9 +3193,9 @@ ip@^1.1.5:
   integrity sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
 
 ipaddr.js@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-2.0.0.tgz#77ccccc8063ae71ab65c55f21b090698e763fc6e"
-  integrity sha512-S54H9mIj0rbxRIyrDMEuuER86LdlgUg9FSeZ8duQb6CUG2iRrA36MYVQBSprTF/ZeAwvyQ5mDGuNvIPM0BIl3w==
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-2.0.1.tgz#eca256a7a877e917aeb368b0a7497ddf42ef81c0"
+  integrity sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng==
 
 is-accessor-descriptor@^0.1.6:
   version "0.1.6"
@@ -3855,17 +3855,17 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
-mime-db@1.47.0:
-  version "1.47.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.47.0.tgz#8cb313e59965d3c05cfbf898915a267af46a335c"
-  integrity sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==
+mime-db@1.48.0:
+  version "1.48.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.48.0.tgz#e35b31045dd7eada3aaad537ed88a33afbef2d1d"
+  integrity sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ==
 
 mime-types@^2.1.12, mime-types@~2.1.19:
-  version "2.1.30"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.30.tgz#6e7be8b4c479825f85ed6326695db73f9305d62d"
-  integrity sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==
+  version "2.1.31"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.31.tgz#a00d76b74317c61f9c2db2218b8e9f8e9c5c9e6b"
+  integrity sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==
   dependencies:
-    mime-db "1.47.0"
+    mime-db "1.48.0"
 
 mimic-fn@^2.1.0:
   version "2.1.0"
@@ -4525,9 +4525,9 @@ pify@^4.0.1:
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
 
 pkcs11js@^1.2.1, pkcs11js@^1.2.3:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/pkcs11js/-/pkcs11js-1.2.4.tgz#2fcfef68d502184fdd64e2851666e42368d17e37"
-  integrity sha512-GI0U+WIKEw6TadYfNvzt88FN2ULGIJ7VwyHEEw/vTgo5eeefXPTdX2Wg2ljCzgTGd+7sdBlpsWdRjq4y7Lntlw==
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/pkcs11js/-/pkcs11js-1.2.5.tgz#d40d21f99e610cab2a7cb452860fc45ae4e6e0a9"
+  integrity sha512-ZOCi2ZqKV6LprMmODsQKxgxnwGyy5nQ+nbI6QeS1M5B7gaH09xIcz8BomukrtyLHs/z3eQvvzy1SAFYXrYOG4w==
   dependencies:
     nan "^2.14.2"
 
@@ -5850,10 +5850,10 @@ tslib@^1.10.0, tslib@^1.11.1, tslib@^1.13.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.1.0, tslib@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
-  integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
+tslib@^2.0.0, tslib@^2.1.0, tslib@^2.2.0, tslib@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
+  integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
 
 tsprotobuf@^1.0.15, tsprotobuf@^1.0.17:
   version "1.0.17"
@@ -6288,10 +6288,10 @@ write@1.0.3:
   dependencies:
     mkdirp "^0.5.1"
 
-ws@^7.4.5:
-  version "7.4.6"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
-  integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
+ws@^7.5.1:
+  version "7.5.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.2.tgz#09cc8fea3bec1bc5ed44ef51b42f945be36900f6"
+  integrity sha512-lkF7AWRicoB9mAgjeKbGqVUekLnSNO4VjKVnuPHpQeOxZOErX6BPXwJk70nFslRCEEA8EVW7ZjKwXaP9N+1sKQ==
 
 xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
Based on https://github.com/PeculiarVentures/fortify/pull/424

### Bug Fixes

- Fix error on `ossl` property reading of null object.
- Change driver for the `3BDF18008131FE7D006B020C0182011101434E53103180FC` token  ([#423](https://github.com/PeculiarVentures/fortify/issues/423)).
- Fix error on key generation ([#422](https://github.com/PeculiarVentures/fortify/issues/422)).
- Fix error on IDPrime card removing ([#421](https://github.com/PeculiarVentures/fortify/issues/421)).