### PR TITLE
Add information to the README that the repository is no longer supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
-# [Archived] This Repository is no longer maintained
-
-⚠️ **Important Notice:** This repository has been archived and is no longer maintained and we are not going to be updating issues or pull requests on this repository. The application has been moved to a new [fortify-releases](https://github.com/PeculiarVentures/fortify-releases) repository.
-
-If you are having a question about Fortify then please contact [support](mailto:support@fortifyapp.com).
+> [!IMPORTANT]
+> This Repository is no longer maintained
+> ⚠️ **Important Notice:** This repository has been archived and is no longer maintained and we are not going to be updating issues or pull requests on this repository. The application has been moved to a new [fortify-releases](https://github.com/PeculiarVentures/fortify-releases) repository.
+> If you are having a question about Fortify then please contact [support](mailto:support@fortifyapp.com).
 
 <p align="center">
   <a href="https://fortifyapp.com/" rel="noopener" target="_blank"><img width="128" src="src/static/icons/tray/png/icon@16x.png" alt="Fortify logo"></a></p>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 > [!CAUTION]
 > **This Repository is no longer maintained** <br />
-> This repository has been archived and is no longer maintained and we  are not going to be updating issues or pull requests on this repository. The application has been moved to a new [fortify-releases](https://github.com/PeculiarVentures/fortify-releases) repository.
+> This repository has been archived and is no longer maintained, also we are not going to be updating issues or pull requests on this repository. The application has been moved to a new [fortify-releases](https://github.com/PeculiarVentures/fortify-releases) repository.
 > If you are having a question about Fortify then please contact [support](mailto:support@fortifyapp.com).
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# [Archived] This Repository is no longer maintained
+
+⚠️ **Important Notice:** This repository has been archived and is no longer maintained and we are not going to be updating issues or pull requests on this repository. The application has been moved to a new [fortify-releases](https://github.com/PeculiarVentures/fortify-releases) repository.
+
+If you are having a question about Fortify then please contact [support](mailto:support@fortifyapp.com).
+
 <p align="center">
   <a href="https://fortifyapp.com/" rel="noopener" target="_blank"><img width="128" src="src/static/icons/tray/png/icon@16x.png" alt="Fortify logo"></a></p>
 </p>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-> [!IMPORTANT]
-> This Repository is no longer maintained
-> ⚠️ **Important Notice:** This repository has been archived and is no longer maintained and we are not going to be updating issues or pull requests on this repository. The application has been moved to a new [fortify-releases](https://github.com/PeculiarVentures/fortify-releases) repository.
+> [!CAUTION]
+> **This Repository is no longer maintained** <br />
+> This repository has been archived and is no longer maintained and we  are not going to be updating issues or pull requests on this repository. The application has been moved to a new [fortify-releases](https://github.com/PeculiarVentures/fortify-releases) repository.
 > If you are having a question about Fortify then please contact [support](mailto:support@fortifyapp.com).
+
+---
 
 <p align="center">
   <a href="https://fortifyapp.com/" rel="noopener" target="_blank"><img width="128" src="src/static/icons/tray/png/icon@16x.png" alt="Fortify logo"></a></p>


### PR DESCRIPTION
Also need to add "The repository is no longer maintained and moved to [fortify-releases](https://github.com/PeculiarVentures/fortify-releases)" or something to the repo about:

<details><summary>Here</summary>
<p>

<img width="304" alt="Screenshot 2024-09-02 at 18 23 09" src="https://github.com/user-attachments/assets/10df7a42-ab6f-4405-8cb0-5979783f9d06">

</p>
</details> 

And probably add the `unmaintained` tag:

<details><summary>here</summary>
<p>

<img width="277" alt="Screenshot 2024-09-02 at 18 24 16" src="https://github.com/user-attachments/assets/1db24455-496e-4881-9163-23563ab15d32">


</p>
</details> 